### PR TITLE
fix: remove unused vitest dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,15 +90,13 @@
 		"@commitlint/cli": "^20.1.0",
 		"@commitlint/config-conventional": "^20.0.0",
 		"@types/node": "^24.8.1",
-		"@vitest/coverage-v8": "^4.0.14",
 		"bun-types": "^1.3.3",
 		"bunup": "^0.16.10",
 		"husky": "^9.1.7",
 		"lint-staged": "^15.2.10",
 		"publint": "^0.3.15",
 		"rimraf": "^6.0.1",
-		"typescript": "^5.9.3",
-		"vitest": "^4.0.14"
+		"typescript": "^5.9.3"
 	},
 	"lint-staged": {
 		"*.{ts,tsx,js,jsx,mts,cts,json}": [


### PR DESCRIPTION
Tests use `bun:test`, not vitest. Remove unnecessary dependencies:
- @vitest/coverage-v8
- vitest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined development dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->