### PR TITLE
fix(setup): remove existing origin before creating new repo

### DIFF
--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -306,6 +306,13 @@ async function run() {
 			if (repoExists.exitCode !== 0) {
 				// Create the repo
 				console.log(`  Creating repository ${githubUser}/${repoName}...`)
+
+				// Remove existing origin if present (template clones have origin set)
+				Bun.spawnSync(['git', 'remote', 'remove', 'origin'], {
+					stdout: 'pipe',
+					stderr: 'pipe',
+				})
+
 				const createResult = Bun.spawnSync(
 					[
 						'gh',


### PR DESCRIPTION
## Summary
Remove existing origin remote before creating a new GitHub repo.

## Problem
Template clones have origin already set (pointing to template repo). When creating a different repo name, `gh repo create --source=.` fails with "Unable to add remote origin".

## Solution
Call `git remote remove origin` before `gh repo create` to ensure clean state.

## Test plan
- [ ] Delete both dogfood repos (`test-template-dogfood` and `core-tools`)
- [ ] Create fresh from template
- [ ] Run setup with different repo name
- [ ] Should see "✅ Repository created and code pushed!" and only 2 next steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository setup process by removing pre-existing remotes during initialization, ensuring cleaner setup workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->