### PR TITLE
fix(setup): bypass pre-push hook during initial setup

### DIFF
--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -325,7 +325,12 @@ async function run() {
 						'--description',
 						description,
 					],
-					{ stdout: 'inherit', stderr: 'inherit' },
+					{
+						stdout: 'inherit',
+						stderr: 'inherit',
+						// Allow push to main during initial setup (bypasses husky pre-push hook)
+						env: { ...process.env, ALLOW_PUSH_PROTECTED: '1' },
+					},
 				)
 
 				if (createResult.exitCode !== 0) {
@@ -364,6 +369,8 @@ async function run() {
 					{
 						stdout: 'inherit',
 						stderr: 'inherit',
+						// Allow push to main during initial setup (bypasses husky pre-push hook)
+						env: { ...process.env, ALLOW_PUSH_PROTECTED: '1' },
 					},
 				)
 


### PR DESCRIPTION
## Summary
Set `ALLOW_PUSH_PROTECTED=1` env var when pushing during setup to bypass the husky pre-push hook.

## Problem
The template includes a husky pre-push hook that blocks direct pushes to main. This is correct for normal development but breaks initial setup where we need to push the initial commit to main.

## Test plan
- [ ] Delete dogfood repos
- [ ] Create fresh from template  
- [ ] Run setup with different repo name
- [ ] Should push successfully and show only 2 next steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated setup script to enable successful push operations during initial repository creation and configuration, ensuring the setup process completes without interruption.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->