### PR TITLE
fix(setup): add echo hint for NPM_TOKEN in next steps

### DIFF
--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -426,6 +426,11 @@ async function run() {
 
 	// NPM_TOKEN must be configured manually per-repo
 	steps.push(`  ${stepNum}. For npm publishing (first time):`)
+	steps.push('     # If you have NPM_TOKEN in your environment:')
+	steps.push(
+		`     echo "$NPM_TOKEN" | gh secret set NPM_TOKEN --repo ${githubUser}/${repoName}`,
+	)
+	steps.push('     # Or set it interactively:')
 	steps.push(`     gh secret set NPM_TOKEN --repo ${githubUser}/${repoName}`)
 	steps.push(
 		'     - After first publish, configure OIDC trusted publishing at:',


### PR DESCRIPTION
Shows both options for setting NPM_TOKEN: piping from env var or interactive prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced setup instructions with clearer guidance for configuring NPM authentication during the publishing process.
  * Added practical examples for both environment variable-based and interactive credential configuration methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->