### PR TITLE
fix(ci): fix cleanup patterns and changesets Node.js resolution

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -87,13 +87,10 @@ jobs:
           # Delete all top-level directories containing @@@* anywhere
           find . -maxdepth 1 -type d -name '*@@@*' -exec rm -rf {} + 2>/dev/null || true
 
-          # Delete scoped packages leaked to root (e.g., @changesets, @babel)
-          find . -maxdepth 1 -type d -name '@*' ! -name '.@*' -exec rm -rf {} + 2>/dev/null || true
-
           # Delete any remaining package-like folders (name@version pattern)
           find . -maxdepth 1 -type d -regex '.*/[a-z].*@[0-9].*' -exec rm -rf {} + 2>/dev/null || true
 
-          rm -rf node_modules/.bun node_modules/.old_modules* 2>/dev/null || true
+          rm -rf node_modules/.old_modules* 2>/dev/null || true
 
           # Verify cleanup
           REMAINING=$(find . -maxdepth 1 -type d ! -name '.' | grep -Evc "^\./($KNOWN_DIRS)$" || echo 0)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Ensure changesets CLI is Node-resolvable
+        run: |
+          # The changesets/action uses Node.js require() internally.
+          # Bun's module layout uses .bun/ symlinks that the action's bundled JS
+          # runtime cannot resolve. npm install --no-save also fails because npm
+          # can't parse Bun's node_modules layout.
+          # Solution: install into a separate prefix and add to NODE_PATH.
+          npm install --prefix .npm-changesets @changesets/cli @changesets/changelog-github
+          echo "NODE_PATH=$(pwd)/.npm-changesets/node_modules" >> "$GITHUB_ENV"
+
       - name: Fix conflicting registry in bunfig.toml
         run: |
           # Setup Bun creates bunfig.toml with registry, which conflicts with Setup Node's registry.
@@ -99,9 +109,8 @@ jobs:
           # Bun 1.3.x hoisted linker leaks packages to project root
           # Delete @@@* suffixed folders, scoped packages (@*), and versioned packages
           find . -maxdepth 1 -type d -name '*@@@*' -exec rm -rf {} + 2>/dev/null || true
-          find . -maxdepth 1 -type d -name '@*' ! -name '.@*' -exec rm -rf {} + 2>/dev/null || true
           find . -maxdepth 1 -type d -regex '.*/[a-z].*@[0-9].*' -exec rm -rf {} + 2>/dev/null || true
-          rm -rf node_modules/.bun node_modules/.old_modules* 2>/dev/null || true
+          rm -rf node_modules/.old_modules* 2>/dev/null || true
 
       - name: Disable git hooks for CI commits
         run: git config --global core.hooksPath /dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage/
 
 # Dependencies
 node_modules/
+.npm-changesets/
 # Bun linker artifacts (hoisted mode creates these in project root)
 # See: https://github.com/oven-sh/bun/issues/23615
 *@@@*/


### PR DESCRIPTION
## Summary

Fixes 4 bugs that caused CI failures during monorepo setup (discovered in `side-quest-runners`):

- **Remove `node_modules/.bun` from cleanup** — Bun uses `.bun/` for package resolution (symlinks, subpath exports). Deleting it breaks `@scope/pkg/subpath` imports in CI.
- **Remove `@*` find pattern** — This deletes ALL scoped directories at project root, including legitimate ones like `@changesets/`. The `*@@@*` and `name@version` patterns already catch actual Bun linker artifacts.
- **Add `npm install --prefix` for changesets** — The `changesets/action` uses bundled Node.js `require()` which can't traverse Bun's `.bun/` symlink layout. Install into a separate prefix directory and export `NODE_PATH`.
- **Add `.npm-changesets/` to `.gitignore`** — The changesets action runs `git add .` which picks up the prefix directory if not gitignored.

## Test plan

- [ ] CI passes on this PR (lint, typecheck, test, build all green)
- [ ] Verify publish workflow structure has the new step in correct position
- [ ] Verify pr-quality.yml cleanup step no longer removes scoped packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflows for improved build and release pipeline reliability.
  * Optimized build system cleanup and dependency resolution processes.
  * Updated version control configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->