### PR TITLE
fix(ci): dispatch PR quality checks on version packages PR

### DIFF
--- a/.github/workflows/version-packages-auto-merge.yml
+++ b/.github/workflows/version-packages-auto-merge.yml
@@ -49,3 +49,21 @@ jobs:
               }
             `, { prId: pr.node_id })
             core.info('Auto-merge enabled for Version Packages PR')
+
+      # GITHUB_TOKEN PRs don't trigger workflows (GitHub anti-recursion).
+      # Dispatch pr-quality.yml using the App token so the required "All
+      # checks passed" gate job runs and branch protection is satisfied.
+      - name: Trigger PR quality checks on version branch
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const branch = context.payload.pull_request.head.ref
+            core.info(`Dispatching PR quality workflow on ${branch}`)
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'pr-quality.yml',
+              ref: branch,
+            })
+            core.info('PR quality workflow dispatched')


### PR DESCRIPTION
## Summary

- The "Version Packages" PR created by `changesets/action` uses `GITHUB_TOKEN`, which GitHub prevents from triggering workflows (anti-recursion). This means `pr-quality.yml` never runs, the required "All checks passed" gate never fires, and branch protection blocks the merge indefinitely.
- Fixes this by adding a step to the auto-merge workflow that dispatches `pr-quality.yml` on the version PR's branch using the GitHub App token, which is not subject to the anti-recursion restriction.

## How it works

1. Changesets action creates "Version Packages" PR with `GITHUB_TOKEN`
2. `pull_request_target` triggers `version-packages-auto-merge.yml` (fires for bot PRs)
3. Existing step: enables auto-merge via App token
4. **New step:** dispatches `pr-quality.yml` on `changeset-release/main` via App token
5. `pr-quality.yml` runs all checks, `gate` job reports "All checks passed"
6. Branch protection is satisfied, auto-merge completes

Closes #42

## Test plan

- [ ] Merge a changeset to main to trigger a "Version Packages" PR
- [ ] Verify `version-packages-auto-merge.yml` runs and dispatches `pr-quality.yml`
- [ ] Verify `pr-quality.yml` runs on the version branch and the gate job passes
- [ ] Verify the version PR auto-merges after the gate check succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated quality assurance workflow to ensure pull requests meet all required checks and branch protection requirements before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->