### PR TITLE
fix(ci): use portable printf format for YAML frontmatter dashes

### DIFF
--- a/.github/scripts/changeset-generate-if-missing.sh
+++ b/.github/scripts/changeset-generate-if-missing.sh
@@ -58,11 +58,11 @@ fi
 
 mkdir -p .changeset
 {
-  printf '---\n'
+  printf '%s\n' '---'
   while IFS= read -r PKG; do
     printf '"%s": %s\n' "$PKG" "$TYPE"
   done <<< "$PACKAGES"
-  printf '---\n\n'
+  printf '%s\n\n' '---'
   printf '%s\n' "$TITLE"
 } >"$FILE"
 


### PR DESCRIPTION
## Summary
- Fixes `printf '---\n'` being interpreted as an invalid option flag on Ubuntu's bash
- Uses `printf '%s\n' '---'` to pass dashes as an argument instead of a format string

Closes #46

## Test plan
- [ ] Verify CI changeset auto-generation works on Ubuntu runners
- [ ] Confirm changeset file output contains correct YAML frontmatter