### PR TITLE
fix: remove CodeRabbit from required status checks

### DIFF
--- a/scripts/setup-protect.ts
+++ b/scripts/setup-protect.ts
@@ -68,7 +68,7 @@ function run() {
 	const protectionPayload = JSON.stringify({
 		required_status_checks: {
 			strict: true,
-			contexts: ['All checks passed', 'CodeRabbit'],
+			contexts: ['All checks passed'],
 		},
 		enforce_admins: true,
 		required_pull_request_reviews: {
@@ -117,9 +117,7 @@ function run() {
 
 	console.log('  ✅ Branch protection enabled on main!')
 	console.log('     - Requires PR for all changes')
-	console.log(
-		'     - Requires status checks: "All checks passed", "CodeRabbit"',
-	)
+	console.log('     - Requires status checks: "All checks passed"')
 	console.log('     - Requires conversation resolution')
 	console.log('     - Requires linear history')
 	console.log('     - Blocks force pushes and branch deletion')


### PR DESCRIPTION
## Summary

- Remove CodeRabbit from required status checks in `setup-protect.ts`
- CodeRabbit doesn't report status on bot/dependabot PRs, blocking merges when it's required
- CodeRabbit still runs and posts review comments -- just won't block when it doesn't report

## Context

This was causing issues across all downstream repos where dependabot PRs couldn't be merged without manually toggling branch protection. Already applied the runtime fix to 4 repos (side-quest-plugins, side-quest-community-intel-cache, bun-typescript-starter, side-quest-kit).

## Test plan

- [x] Verify `bun run setup:protect` only requires "All checks passed"
- [x] Verify CodeRabbit still posts reviews (not a required check, just advisory)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch protection requirements configuration to require only "All checks passed" status check, removing an additional check requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->