### PR TITLE
fix(ci): prevent merge when gate job is skipped due to upstream failure

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -203,10 +203,23 @@ jobs:
     name: All checks passed
     runs-on: ubuntu-latest
     needs: [lint, typecheck, test, quality, lint-scripts]
+    if: always()
     timeout-minutes: 5
     steps:
-      - name: Aggregate result
-        run: echo "All prerequisite PR quality jobs succeeded." && exit 0
+      - name: Check all jobs
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled"
+            echo
+            echo "Results:"
+            echo "  Lint: ${{ needs.lint.result }}"
+            echo "  Typecheck: ${{ needs.typecheck.result }}"
+            echo "  Tests + Coverage: ${{ needs.test.result }}"
+            echo "  Repo quality: ${{ needs.quality.result }}"
+            echo "  Lint Shell Scripts: ${{ needs.lint-scripts.result }}"
+            exit 1
+          fi
+          echo "All prerequisite PR quality jobs succeeded."
       - name: PR summary
         if: always()
         shell: bash


### PR DESCRIPTION
## Summary

- Add `if: always()` to the `gate` job so it runs even when upstream jobs fail
- Explicitly check for `failure` or `cancelled` in upstream job results and exit 1

**Why:** GitHub treats `skipped` status checks as passing. When a job like `test` fails, the `gate` job ("All checks passed") gets skipped rather than failed, which means branch protection allows merging despite broken checks.

## Test plan

- [ ] Create a PR with a deliberately failing test -- gate job should now **fail** instead of being skipped
- [ ] Create a PR with all tests passing -- gate job should pass as before
- [ ] actionlint passes locally (verified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced PR quality check validation with detailed reporting of individual check results (lint, typecheck, tests+coverage, repo quality, lint-scripts).
  * Improved quality gate to ensure all prerequisite checks are validated and provide clearer feedback on failures or cancellations.
  * Added more comprehensive PR summary output to assist developers in understanding quality check results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->