### PR TITLE
fix(ci): allow dependabot GHA bumps to auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,17 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Require dev-dependencies label
+      - name: Require auto-mergeable label
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: labels
         with:
           script: |
             const labels = (context.payload.pull_request.labels || []).map(l => l.name)
-            const hasDevLabel = labels.includes('dev-dependencies')
-            if (!hasDevLabel) {
-              core.setFailed('PR is not labeled dev-dependencies; skipping auto-merge')
+            const allowed = ['dev-dependencies', 'github_actions']
+            const hasAllowed = labels.some(l => allowed.includes(l))
+            if (!hasAllowed) {
+              core.setFailed(`PR labels [${labels.join(', ')}] do not include any of: ${allowed.join(', ')}`)
             }
-      - name: Check changed files for devDependencies only
+      - name: Check changed files are safe to auto-merge
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: diff
         with:
@@ -41,11 +42,12 @@ jobs:
               'yarn.lock',
               'bun.lock',
             ]
-            const onlyAllowed = filenames.every(f => allowed.includes(f))
-            if (!onlyAllowed) {
-              core.setFailed('PR touches files outside dependency manifests')
+            const isGHA = filenames.every(f => f.startsWith('.github/'))
+            const isDeps = filenames.every(f => allowed.includes(f))
+            if (!isGHA && !isDeps) {
+              core.setFailed('PR touches files outside dependency manifests and .github/')
             }
-      - name: Enable auto-merge for minor/patch dev dependency updates
+      - name: Enable auto-merge for minor/patch dependency updates
         if: steps.diff.outcome == 'success' && steps.labels.outcome == 'success'
         uses: fastify/github-action-merge-dependabot@1b2ed42db8f9d81a46bac83adedfc03eb5149dff # v3.11.2
         with:


### PR DESCRIPTION
## Summary
- Auto-merge workflow only accepted the `dev-dependencies` label, but GitHub Actions version bumps from dependabot are labeled `github_actions` - so all GHA dependabot PRs were failing the label gate
- File safety check only allowed lockfiles/package.json, but GHA bumps touch `.github/` workflow files - added `.github/` prefix as an allowed path

## Context
All three open dependabot PRs in `side-quest-last-30-days` (#4, #5, #6) are stuck because of this. The downstream repo also has a separate `printf '---\n'` bug in the changeset script (already fixed in this template).

## Test plan
- [ ] Verify actionlint passes (ran locally, 0 errors)
- [ ] After merge, re-run dependabot auto-merge workflows on downstream repos to confirm GHA bumps get auto-merged